### PR TITLE
GetOffset with negative offset values

### DIFF
--- a/src/core/VL53L1X_api.cpp
+++ b/src/core/VL53L1X_api.cpp
@@ -662,8 +662,8 @@ VL53L1X_ERROR  VL53L1X_GetOffset(uint16_t dev, int16_t *offset)
 
 	status = VL53L1_RdWord(dev,ALGO__PART_TO_PART_RANGE_OFFSET_MM, &Temp);
 	Temp = Temp<<3;
-	Temp = Temp>>5;
 	*offset = (int16_t)(Temp);
+	*offset = *offset / 32;
 	return status;
 }
 


### PR DESCRIPTION
1. Fix the GetOffset function to correctly return negative values.
   Previously, all the bit shifts were done on the unsigned variable,
   meaning that the sign bit will never be set, resulting in incorrect
   offset values being "read" from the chip (e.g. setting offset of -57
   would result in GetOffset returning 1991)
   The correct way is to cast to signed after the initial left shift so
   that the sign bit, if present, is set.
   Also, the value read from the chip has 3 highest bits set to 0. For
   example, the same -57 offset is 65308 when multiplied by 4 and cast
   to uint16, but, the chip will return 7964 (which is 65308&0x1fff),
   hence the need for <<3 to see if the value was negative. Only
   values between -1024 and 1023 are valid, apparently.